### PR TITLE
Add StateT.liftf()

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -55,6 +55,12 @@ State.StateT = (M) => {
         });
     };
 
+    StateT.liftf = (f) => (m) => {
+        return StateT((s) => {
+            return f(m.evalState(s)).map((x) => Tuple2(x, s));
+        });
+    };
+
     StateT.of = (a) => {
         return StateT((b) => M.of(Tuple2(a, b)));
     };

--- a/src/state.js
+++ b/src/state.js
@@ -55,6 +55,7 @@ State.StateT = (M) => {
         });
     };
 
+    // https://hackage.haskell.org/package/mmorph-1.0.9/docs/Control-Monad-Morph.html#g:1
     StateT.hoist = (f) => (m) => {
         return StateT((s) => {
             return f(m.evalState(s)).map((x) => Tuple2(x, s));

--- a/src/state.js
+++ b/src/state.js
@@ -55,7 +55,7 @@ State.StateT = (M) => {
         });
     };
 
-    StateT.liftf = (f) => (m) => {
+    StateT.hoist = (f) => (m) => {
         return StateT((s) => {
             return f(m.evalState(s)).map((x) => Tuple2(x, s));
         });

--- a/test/lib/test.js
+++ b/test/lib/test.js
@@ -4,14 +4,38 @@ const λ = require('fantasy-check/src/adapters/nodeunit');
 const applicative = require('fantasy-check/src/laws/applicative');
 const functor = require('fantasy-check/src/laws/functor');
 const monad = require('fantasy-check/src/laws/monad');
-    
+const helpers = require('fantasy-check/src/laws/helpers');
+
 const daggy = require('daggy');
 
 const {isInstanceOf} = require('fantasy-helpers');
-const {constant, identity} = require('fantasy-combinators');
+const {constant, identity, compose} = require('fantasy-combinators');
 
 const Identity = require('fantasy-identities');
 const State = require('../../fantasy-states');
+
+const equality = helpers.equality;
+
+const mfunctor = {
+    composition: function(λ) {
+        return function(T, unpack) {
+            return λ.check(function(a) {
+                var x = T.hoist(compose(identity)(identity))(T.of(a)),
+                    y = compose(T.hoist(identity))(T.hoist(identity))(T.of(a));
+                return equality(unpack(x), unpack(y));
+            }, [λ.AnyVal]);
+        };
+    },
+    identity: function(λ) {
+        return function(T, unpack) {
+            return λ.check(function(a) {
+                var x = T.hoist(identity)(T.of(a)),
+                    y = identity(T.of(a));
+                return equality(unpack(x), unpack(y));
+            }, [λ.AnyVal]);
+        };
+    }
+};
 
 const isIdentity = isInstanceOf(Identity);
 const isState = isInstanceOf(State);
@@ -30,6 +54,7 @@ function identityOf(type) {
 const λʹ = λ
     .property('applicative', applicative)
     .property('functor', functor)
+    .property('mfunctor', mfunctor)
     .property('monad', monad)
     .property('State', State)
     .property('Identity', Identity)

--- a/test/state.js
+++ b/test/state.js
@@ -3,6 +3,7 @@
 const λ = require('./lib/test');
 const applicative = λ.applicative;
 const functor = λ.functor;
+const mfunctor = λ.mfunctor;
 const monad = λ.monad;
 const identity = λ.identity;
 const State = λ.State;
@@ -53,16 +54,8 @@ exports.stateT = {
     'Right Identity (Monad)': monad.rightIdentity(λ)(State.StateT(Identity), run),
     'Associativity (Monad)': monad.associativity(λ)(State.StateT(Identity), run),
 
-    // Helper tests
-    'liftf': (test) => {
-        const Inner = Identity;
-        const Outer = State.StateT(Inner);
-        const f = (id) => Inner.of(id.x + 1);
-        const f_ = Outer.liftf(f);
-        const actual = f_(Outer.of(1));
-        test.ok(actual instanceof Outer, '_f returned an Outer');
-        test.equal(actual.evalState().x, 2, 'f was applied to inner');
-        test.done();
-    }
+    //MFunctor tests
+    'Composition (MFunctor)': mfunctor.composition(λ)(State.StateT(Identity), run),
+    'Identity (MFunctor)': mfunctor.identity(λ)(State.StateT(Identity), run),
 
 };

--- a/test/state.js
+++ b/test/state.js
@@ -51,5 +51,18 @@ exports.stateT = {
     'All (Monad)': monad.laws(λ)(State.StateT(Identity), run),
     'Left Identity (Monad)': monad.leftIdentity(λ)(State.StateT(Identity), run),
     'Right Identity (Monad)': monad.rightIdentity(λ)(State.StateT(Identity), run),
-    'Associativity (Monad)': monad.associativity(λ)(State.StateT(Identity), run)
+    'Associativity (Monad)': monad.associativity(λ)(State.StateT(Identity), run),
+
+    // Helper tests
+    'liftf': (test) => {
+        const Inner = Identity;
+        const Outer = State.StateT(Inner);
+        const f = (id) => Inner.of(id.x + 1);
+        const f_ = Outer.liftf(f);
+        const actual = f_(Outer.of(1));
+        test.ok(actual instanceof Outer, '_f returned an Outer');
+        test.equal(actual.evalState().x, 2, 'f was applied to inner');
+        test.done();
+    }
+
 };


### PR DESCRIPTION
This allows a function written to operate on the inner structure to be lifted to a function which operates over the whole structure, increasing code-reusability.

I have a use-case for this function in my [momi](https://github.com/Avaq/momi) project. [See here for use-case.](https://github.com/Avaq/momi/blob/master/examples/readme/index.js#L21)  In order to support this case, I've [implemented](https://github.com/Avaq/momi/blob/master/lib/app.js#L53-L54) `liftf` myself, but as you can see it requires knowledge and reverse-engineering of `State`s internals, so I think it's more appropriate if this function would live within `fantasy-states`.